### PR TITLE
fix: cannot be compiled bc erc721a needs >=0.8.13

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -153,7 +153,7 @@ task(
 // Go to https://hardhat.org/config/ to learn more
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.9",
+    version: "0.8.13",
     settings: {
       optimizer: {
         enabled: true,


### PR DESCRIPTION
## Error
```
 % yarn test
yarn run v1.22.18
$ hardhat test
Error HH606: The project cannot be compiled, see reasons below.

The Solidity version pragma statement in these files doesn't match any of the configured compilers in your config. Change the pragma or configure additional compiler versions in your hardhat config.

  * erc721a/contracts/ERC721A.sol (^0.8.13)
```